### PR TITLE
Enhance the build target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+*/*.nupkg
 packages
 .nuget
 **.userprefs
+bin
+obj
+

--- a/Jay.MSBuild.Target/Jay.MSBuild.Target.nuspec
+++ b/Jay.MSBuild.Target/Jay.MSBuild.Target.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata minClientVersion="2.8.5">
     <id>Jay.MSBuild</id>
-    <version>0.2.0</version>
+    <version>0.2.1</version>
     <authors>SushiHangover\RobertN</authors>
     <owners>SushiHangover\RobertN</owners>
     <projectUrl>https://github.com/PlayScriptRedux/Jay.MSBuild.Target</projectUrl>
@@ -18,6 +18,7 @@
     <releaseNotes>
     Jay.MSBuild.Target release notes:
 
+    0.2.1 Uodate : Enhance build target to allow `.jay` files outside of src dir via filtering the @None ItemGroup
     0.2.0 Uodate : Added OS-X Support (jay.darwin) 
     0.1.0 New    : Initial Test Release
     </releaseNotes>

--- a/Jay.MSBuild.Target/Makefile
+++ b/Jay.MSBuild.Target/Makefile
@@ -14,7 +14,7 @@ task:
 
 clean:
 	xbuild /target:Clean /p:Configuration=${CONFIG} ${ARGS}
-	-rm Jay.MSBuild.Target.*.nupkg
+	-rm Jay.MSBuild.*.nupkg
 
 publish: clean all
 	nuget push Jay.MSBuild.*.nupkg $(MyGetApiKey) -source https://www.myget.org/F/playscript/api/v2

--- a/Jay.MSBuild.Target/build/Jay.MSBuild.Targets
+++ b/Jay.MSBuild.Target/build/Jay.MSBuild.Targets
@@ -32,14 +32,23 @@
 
 	<!-- Get all jay files in the current project -->
 	<ItemGroup>
-		<JayFiles Include="**\*.jay"/>
+		<JayFiles Include="%(AllFiles.Identity)" Condition="$([System.Text.RegularExpressions.Regex]::IsMatch(%(Filename), '\.jay\'))"/>
 	</ItemGroup>
 
-	<Target Name="JayGenerate"
-		Inputs="@(JayFiles)"
-		Outputs="@(JayFiles->'$(IntermediateOutputPath)%(FileName).cs')"
-		Condition="'$(BuildingProject)'!='false'"
-		>
+	<!-- Get all jay files in the current project -->
+	<Target Name="JayFiles">
+		<ItemGroup>
+			<JayFiles Include="@(None)" Condition="'%(Extension)' == '.jay' " />
+		</ItemGroup>
+		<Message Text="                JayFiles: %(JayFiles.Identity) "/>
+	</Target>
+
+    <Target Name="JayGenerate"
+            Inputs="@(JayFiles)"
+            Outputs="@(JayFiles->'$(IntermediateOutputPath)%(FileName).cs')"
+            Condition="'$(BuildingProject)'!='false'"
+            DependsOnTargets="JayFiles"
+            >
 		<MakeDir Directories="$(IntermediateOutputPath)"/>
 		<!--Nuget does not preserve file attribs and OS-X/Linux do not have Nuget install scripts, so hack it. :-( -->
 		<Exec Condition=" '$(OS)' == 'UNIX' " Command="chmod a+x $(JayFullPath)" />
@@ -60,5 +69,6 @@
 		<Message Text="     MSBuildThisFileName: $(MSBuildThisFileName) "/>
 		<Message Text="         BuildingProject: $(BuildingProject) "/>
 		<Message Text="  IntermediateOutputPath: $(IntermediateOutputPath) "/>
+		<Message Text="  AllFiles: %(AllFiles.Identity) "/>
 	</Target>
 </Project>


### PR DESCRIPTION
Enhance the build target to use the @(None) item group to filter `.jay` files
    so they can be located outside of the project directory
